### PR TITLE
bugfix for pica_map to handle subfield code 0

### DIFF
--- a/lib/Catmandu/Fix/pica_map.pm
+++ b/lib/Catmandu/Fix/pica_map.pm
@@ -118,9 +118,10 @@ sub parse_pica_path {
     if ( $path =~ /(\d{3}\S)(\[(\d{2})\])?([_A-Za-z0-9]+)?(\/(\d+)(-(\d+))?)?/ ) {
         my $field    = $1;
         my $occurrence = $3;
-        my $subfield = $4 ? "[$4]" : "[_A-Za-z0-9]";
+        my $subfield = defined $4 ? "[$4]" : "[_A-Za-z0-9]";
         my $from     = $6;
         my $to       = $8;
+
         return {
             field    => $field,
             occurrence => $occurrence,

--- a/t/bugfix_pica_map.t
+++ b/t/bugfix_pica_map.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Catmandu;
+use Catmandu::Fix;
+use Catmandu::Importer::PICA;
+
+my $fixer = Catmandu::Fix->new(fixes => ['pica_map("007G0", "subfield_zero")','pica_map("007Gc", "subfield_c")','remove_field("record"),','remove_field("_id"),']);
+my $importer = Catmandu::Importer::PICA->new(file => "./t/files/picaxml.xml", type=> "XML");
+my $records = $fixer->fix($importer)->to_array;
+
+is( $records->[0]->{'subfield_c'}, 'GBV', 'get subfield c' );
+is( $records->[0]->{'subfield_zero'}, '658700774', 'get subfield 0' );
+
+done_testing();


### PR DESCRIPTION
- bugfix for pica_map() to handle subfield code '0' correctly.
- added test bugfix_pica_map.t
